### PR TITLE
Amend--fix default form behavior and template layout

### DIFF
--- a/bridge/bridgeapp/forms.py
+++ b/bridge/bridgeapp/forms.py
@@ -5,14 +5,29 @@ CAT_CHOICES = [(f"{category.id}", f"{category.type}")
                for category in Category.objects.all()]
 
 
-class InputForm(forms.Form):
-    body = forms.CharField(label='', widget=forms.Textarea(
-        attrs={'rows': '2', 'cols': '50'}), required=True, )
+class ResponseForm(forms.Form):
+    body = forms.CharField(
+        required=True,
+        label='',
+        widget=forms.Textarea(attrs={
+            'rows': '2',
+            'cols': '50',
+            'placeholder': 'Write a response here.'
+            }))
 
 
-class ThreadForm(InputForm):
+class ThreadForm(forms.Form):
+    body = forms.CharField(
+        required=True,
+        label='',
+        widget=forms.Textarea(attrs={
+            'rows': '2',
+            'cols': '50',
+            'placeholder': 'Post a question here.'
+            }))
     category_ids = forms.MultipleChoiceField(
+        required=True,
         label='Check applicable categories',
-        widget=forms.CheckboxSelectMultiple, choices=CAT_CHOICES,
-        required=True
+        widget=forms.CheckboxSelectMultiple(attrs={'checked': True}),
+        choices=CAT_CHOICES,
     )

--- a/bridge/bridgeapp/templates/category.html
+++ b/bridge/bridgeapp/templates/category.html
@@ -1,30 +1,27 @@
-{% extends 'home.html' %}
-
-{% block main %}
-    <h2>{{ category.type }}</h2>
-    <section>
-        <ol>
-            {% for thread in threads %}
-            <li>
-                <div class="threadDiv">
-                    <a href="{% url 'thread' thread_id=thread.id resp_id=0 %}">
-                        Q{{ forloop.counter }}: {{ thread.body }}
-                    </a>
-                    Created: {{ thread.date }}
-                </div>
-            </li>
-            {% endfor %}
-        </ol>
-    </section>
-    <section>
-
-        <form
-            action="{% url 'category' category.id category.type|slugify %}"
-            method="POST"
-        >
-            {% csrf_token %}
-            {{ thread_form }}
-            <input type="submit" name="add" value="Submit" />
-        </form>
-    </section>
+{% extends 'home.html' %} {% block main %}
+<h2>{{ category.type }}</h2>
+<section>
+    <ol>
+        {% for thread in threads %}
+        <li>
+            <div class="threadDiv">
+                <a href="{% url 'thread' thread_id=thread.id resp_id=0 %}">
+                    Q{{ forloop.counter }}: {{ thread.body }}
+                </a>
+                Created: {{ thread.date }}
+            </div>
+        </li>
+        {% endfor %}
+    </ol>
+</section>
+<section>
+    <form
+        action="{% url 'category' category.id category.type|slugify %}"
+        method="POST"
+    >
+        {% csrf_token %}
+        {{ thread_form.as_p }}
+        <input type="submit" name="add" value="Submit" />
+    </form>
+</section>
 {% endblock %}}

--- a/bridge/bridgeapp/views.py
+++ b/bridge/bridgeapp/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect
 from django.views import View
 from django.utils.text import slugify
 from .models import Category, Thread, Response
-from .forms import InputForm, ThreadForm
+from .forms import ResponseForm, ThreadForm
 from datetime import date
 
 CATEGORIES = Category.objects.all()
@@ -26,7 +26,7 @@ class BridgeCategoryView(View):
     def get(self, request, category_id, category_slug):
         category = Category.objects.get(id=category_id)
         threads = Thread.objects.filter(categories=category).order_by('-date')
-        form = ThreadForm(initial={'body': 'What do you want to ask?'})
+        form = ThreadForm()
 
         return render(
             request=request,
@@ -52,7 +52,6 @@ class BridgeCategoryView(View):
                 for cat_id in cat_ids:
                     category = Category.objects.get(id=cat_id)
                     thread.categories.add(category)
-        delete_commented_out_code
                 id, slug = cat_ids[0], slugify(
                     Category.objects.get(id=cat_ids[0]).type)
 
@@ -63,8 +62,7 @@ class BridgeThreadView(View):
     def get(self, request, thread_id, resp_id):
         thread = Thread.objects.get(id=thread_id)
         responses = Response.objects.filter(thread=thread)
-        form = InputForm(initial={
-            'body': 'Write a response to the question.' if not resp_id else Response.objects.get(id=resp_id).body})
+        form = ResponseForm(initial={'body': Response.objects.get(id=resp_id).body if resp_id else ''})
 
         return render(
             request=request,
@@ -81,7 +79,7 @@ class BridgeThreadView(View):
 
     def post(self, request, thread_id, resp_id):
         # return redirect('response', thread_id)
-        form = InputForm(request.POST)
+        form = ResponseForm(request.POST)
         if form.is_valid():
             resp_text = form.cleaned_data['body']
             if 'create' in request.POST:


### PR DESCRIPTION
Amend prior PR#30 for oversight:

Make placeholder text and checked boxes default and add paragraph layout for form elements in HTML, as set forth in Issue #29. The modification of form layout in `category.html` is for ease of view in the MVP state and can be rearranged in final layout.

Also removed is the text `delete_commented_out_code` in line 55 of `/bridge/bridgeapp/views.py` that was left in place in merging of PR #28. It raises exceptions when attempting to run the server.