### PR TITLE
Correct type in home.html and add listener to clear form text on cancellation of update action

### DIFF
--- a/bridge/bridgeapp/static/js/category.js
+++ b/bridge/bridgeapp/static/js/category.js
@@ -1,16 +1,18 @@
 document.addEventListener("DOMContentLoaded", (e) => {
-  // Pop the model in thread.html if the ResponseForm
-  // <textarea> (response.body) is preloaded with data
-  const threadForm = document.getElementById("thread-form");
-  const checkbox1 = document.getElementById(('id_category_ids_0'));
-  const checkbox2 = document.getElementById(('id_category_ids_1'));
-  const checkbox3 = document.getElementById(('id_category_ids_2'));
-  const checkboxes = [checkbox1, checkbox2, checkbox3]
+    // Pop the model in thread.html if the ResponseForm
+    // <textarea> (response.body) is preloaded with data
+    const threadForm = document.getElementById("thread-form");
+    const checkbox1 = document.getElementById("id_category_ids_0");
+    const checkbox2 = document.getElementById("id_category_ids_1");
+    const checkbox3 = document.getElementById("id_category_ids_2");
+    const checkboxes = [checkbox1, checkbox2, checkbox3];
 
-  threadForm.addEventListener('submit', (e) => {
-    if (!checkboxes.some(el => el.checked)) {
-      e.preventDefault();
-      alert("You must check at least one of the checkboxes to submit your question!");
-    }
-  });
+    threadForm.addEventListener("submit", (e) => {
+        if (!checkboxes.some((el) => el.checked)) {
+            e.preventDefault();
+            alert(
+                "You must check at least one of the checkboxes to submit your question!"
+            );
+        }
+    });
 });

--- a/bridge/bridgeapp/static/js/response.js
+++ b/bridge/bridgeapp/static/js/response.js
@@ -1,27 +1,30 @@
 document.addEventListener("DOMContentLoaded", (e) => {
-  // Pop the model in thread.html if the ResponseForm
-  // <textarea> (response.body) is preloaded with data
-  const respForm = document.getElementById('response-form');
-  const respText = respForm.body.value;
-  const showModalBtn = document.getElementById('response-form-btn');
+    // Pop the model in thread.html if the ResponseForm
+    // <textarea> (response.body) is preloaded with data
+    const respForm = document.getElementById("response-form");
+    const respText = respForm.body.value;
+    const showModalBtn = document.getElementById("response-form-btn");
 
-  if (respText) {
-    showModalBtn.click();
-    const modalHeader = document.querySelector('.modal-header');
-    const modalFooter = document.querySelector('.modal-footer');
-    const closeBtn = document.querySelector('.btn-close');
-    const cancelBtn = document.getElementById('btn-cancel');
-    const link = document.createElement('a');
-    link.className = "btn btn-close";
-    link.href = respForm.action.slice(0,-1) + '0'
-    const subBtn = document.createElement('a');
-    subBtn.className = "btn btn-secondary";
-    subBtn.textContent = "Cancel";
-    subBtn.href = respForm.action.slice(0,-1) + '0'
-    modalHeader.removeChild(closeBtn);
-    modalHeader.append(link);
-    modalFooter.removeChild(cancelBtn);
-    modalFooter.insertBefore(subBtn, modalFooter.firstChild)
-    // console.log(modalHeader, modalFooter, closeBtn, cancelBtn);
-  }
+    if (respText) {
+        showModalBtn.click();
+        const modalContent = document.querySelector("modal-content");
+        const modalHeader = document.querySelector(".modal-header");
+        const modalFooter = document.querySelector(".modal-footer");
+        const closeBtn = document.querySelector(".btn-close");
+        const cancelBtn = document.getElementById("btn-cancel");
+        const link = document.createElement("a");
+        link.className = "btn btn-close";
+        link.href = respForm.action.slice(0, -1) + "0";
+        const subBtn = document.createElement("a");
+        subBtn.className = "btn btn-secondary";
+        subBtn.textContent = "Cancel";
+        subBtn.href = respForm.action.slice(0, -1) + "0";
+        modalHeader.removeChild(closeBtn);
+        modalHeader.append(link);
+        modalFooter.removeChild(cancelBtn);
+        modalFooter.insertBefore(subBtn, modalFooter.firstChild);
+        modalContent.addEventListener("click", (e) => {
+            if (e.target.tagName === "A") respForm.body.value = "";
+        });
+    }
 });

--- a/bridge/bridgeapp/templates/home.html
+++ b/bridge/bridgeapp/templates/home.html
@@ -6,7 +6,7 @@
 {% block main %}
 <section class="main-message mb-5">
     <p class="message p-4 p-md-5 rounded shadow">
-        Bridge provides a space primarily for the justice impacted community to seek and offer empirical information about the criminal justice system, namely, information related to pre-commitment proceedings, reality of incarceration, and post-release life. Anyone who has not been invovled directly with the criminal justice system, to include the families and friends of those who have, may also find voices here which address their concerns or answer their questions about a system that significantly impacts millions of lives and the society as a whole. We offer a forum for demystifying aspects of the criminal justice system through the experiences of those who have have been there and who can identify most with those who are effected and want answers.
+        Bridge provides a space primarily for the justice impacted community to seek and offer empirical information about the criminal justice system, namely, information related to pre-commitment proceedings, reality of incarceration, and post-release life. Anyone who has not been invovled directly with the criminal justice system, to include the families and friends of those who have, may also find voices here which address their concerns or answer their questions about a system that significantly impacts millions of lives and the society as a whole. We offer a forum for demystifying aspects of the criminal justice system through the experiences of those who have been there and who can identify most with those who are effected and want answers.
     </p>
 </section>
 


### PR DESCRIPTION
Corrected a typo (duplicate "have") in the homepage section classNamed `.main-message` and added an event listener to the close and cancel buttons in the modal for the `thread.html` page. The listener fires to clear the `<textarea>` content when either of the buttons is clicked--i.e., when the update/remove action is canceled and page returns to normal view. The uncleared content was suspect to the page's occasional buggy refusal to render the normal view on either of the button click.